### PR TITLE
DEVSITE-874: Removed commerce-events index

### DIFF
--- a/product-index-map.json
+++ b/product-index-map.json
@@ -126,10 +126,6 @@
                 "indexPathPrefix": "/commerce/testing/"
             },
             {
-                "indexName": "commerce-events",
-                "indexPathPrefix": "/commerce/events/"
-            },
-            {
                 "indexName": "commerce-extensibility",
                 "indexPathPrefix": "/commerce/extensibility/"
             }


### PR DESCRIPTION
Content from AdobeDocs/commerc-events migrated to AdobeDocs/commerc-extensibility, so this index mapping can be removed.

Migrated content has already been reindexed in the new repo.